### PR TITLE
pkg-config version fix

### DIFF
--- a/configure
+++ b/configure
@@ -548,6 +548,12 @@ if [ -z "$BITLBEE_VERSION" -a -d .bzr ] && type bzr > /dev/null 2> /dev/null; th
 	BITLBEE_VERSION=$REAL_BITLBEE_VERSION-bzr$nick-$rev
 fi
 
+if [ -z "$BITLBEE_VERSION" -a -d .git ] && type git > /dev/null 2> /dev/null; then
+	rev=`git describe --long --tags`
+	echo 'Using '$rev' as git version number'
+	BITLBEE_VERSION=$rev-git
+fi
+
 if [ -n "$BITLBEE_VERSION" ]; then
 	echo 'Spoofing version number: '$BITLBEE_VERSION
 	echo '#undef BITLBEE_VERSION' >> config.h


### PR DESCRIPTION
Closes #1 

More simple configure crap

Just needs a bit more of testing, maybe. The git version string part is in a separate commit since it might get rejected upstream, heh.
