### PR TITLE
Allow filtering of blist output

### DIFF
--- a/doc/user-guide/commands.xml
+++ b/doc/user-guide/commands.xml
@@ -1789,12 +1789,16 @@
 	</bitlbee-command>
 
 	<bitlbee-command name="blist">
-		<syntax>blist [all|online|offline|away]</syntax>
+		<syntax>blist [all|online|offline|away] [&lt;pattern&gt;]</syntax>
 		<short-description>List all the buddies in the current channel</short-description>
 
 		<description>
 			<para>
 				You can get a more readable buddy list using the <emphasis>blist</emphasis> command. If you want a complete list (including the offline users) you can use the <emphasis>all</emphasis> argument.
+			</para>
+
+			<para>
+				A perl-compatible regular expression can be supplied as <emphasis>pattern</emphasis> to filter the results (case-insensitive).
 			</para>
 		</description>
 


### PR DESCRIPTION
Add an (optional) second parameter to blist. If present, it is treated
as regex and used to filter the result list.

---

Patch from http://bugs.bitlbee.org/bitlbee/ticket/972

Replaces #5 
