### PR TITLE
Makefile: Use wildcard for headers to avoid missing files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 # Program variables
 objects = bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o $(OTR_BI) query.o root_commands.o set.o storage.o $(STORAGE_OBJS)
-headers = bitlbee.h commands.h conf.h config.h help.h ipc.h irc.h log.h nick.h query.h set.h sock.h storage.h lib/events.h lib/ftutil.h lib/http_client.h lib/ini.h lib/json.h lib/json_util.h lib/md5.h lib/misc.h lib/proxy.h lib/sha1.h lib/ssl_client.h lib/url.h protocols/account.h protocols/bee.h protocols/ft.h protocols/nogaim.h
+headers = $(wildcard *.h lib/*.h protocols/*.h)
 subdirs = lib protocols
 
 ifeq ($(TARGET),i586-mingw32msvc)


### PR DESCRIPTION
The following headers were missing:

dcc.h otr.h lib/base64.h lib/oauth2.h lib/oauth.h lib/xmltree.h

Fixes bug #36, replaces PR #37.
