### PR TITLE
Fix compiler warnings on Cygwin and Mac OS X.

### DIFF
--- a/configure
+++ b/configure
@@ -48,12 +48,22 @@ ssl=auto
 
 pie=1
 
+
+
 arch=`uname -s`
 cpu=`uname -m`
 
 GLIB_MIN_VERSION=2.14
 
 echo BitlBee configure
+
+# Cygwin and Darwin don't support PIC/PIE
+case "$arch" in
+    CYGWIN* )
+        pie=0;;
+    Darwin )
+        pie=0;;
+esac
 
 while [ -n "$1" ]; do
 	e="`expr "X$1" : 'X--\(.*=.*\)'`"

--- a/dcc.c
+++ b/dcc.c
@@ -521,7 +521,7 @@ file_transfer_t *dcc_request( struct im_connection *ic, char* const* ctcp )
 		filename = ctcp[2];
 		
 		host = ctcp[3];
-		while( *host && isdigit( *host ) ) host++; /* Just digits? */
+		while( *host && isdigit( (unsigned char)*host ) ) host++; /* Just digits? */
 		if( *host == '\0' )
 		{
 			struct in_addr ipaddr = { .s_addr = htonl( atoll( ctcp[3] ) ) };

--- a/ipc.c
+++ b/ipc.c
@@ -525,7 +525,9 @@ static void ipc_command_exec( void *data, char **cmd, const command_t *commands 
 		if( g_strcasecmp( commands[i].command, cmd[0] ) == 0 )
 		{
 			/* There is no typo in this line: */
-			for( j = 1; cmd[j]; j ++ ); j --;
+			for( j = 1; cmd[j]; j ++ )
+				; 
+			j --;
 			
 			if( j < commands[i].required_parameters )
 				break;

--- a/irc_channel.c
+++ b/irc_channel.c
@@ -574,7 +574,7 @@ static gboolean control_channel_privmsg( irc_channel_t *ic, const char *msg )
 	const char *s;
 	
 	/* Scan for non-whitespace chars followed by a colon: */
-	for( s = msg; *s && !isspace( *s ) && *s != ':' && *s != ','; s ++ ) {}
+	for( s = msg; *s && !isspace( (unsigned char)*s ) && *s != ':' && *s != ','; s ++ ) {}
 	
 	if( *s == ':' || *s == ',' )
 	{
@@ -582,7 +582,7 @@ static gboolean control_channel_privmsg( irc_channel_t *ic, const char *msg )
 		
 		memset( to, 0, sizeof( to ) );
 		strncpy( to, msg, s - msg );
-		while( *(++s) && isspace( *s ) ) {}
+		while( *(++s) && isspace( (unsigned char)*s ) ) {}
 		msg = s;
 		
 		if( !( iu = irc_user_by_name( irc, to ) ) )

--- a/irc_commands.c
+++ b/irc_commands.c
@@ -769,7 +769,9 @@ void irc_exec( irc_t *irc, char *cmd[] )
 		if( g_strcasecmp( irc_commands[i].command, cmd[0] ) == 0 )
 		{
 			/* There should be no typo in the next line: */
-			for( n_arg = 0; cmd[n_arg]; n_arg ++ ); n_arg --;
+			for( n_arg = 0; cmd[n_arg]; n_arg ++ )
+				; 
+			n_arg --;
 			
 			if( irc_commands[i].flags & IRC_CMD_PRE_LOGIN && irc->status & USTATUS_LOGGED_IN )
 			{

--- a/irc_im.c
+++ b/irc_im.c
@@ -72,7 +72,7 @@ static gboolean bee_irc_user_new( bee_t *bee, bee_user_t *bu )
 		else
 		{
 			char *s;
-			for( s = bu->ic->acc->tag; isalnum( *s ); s ++ );
+			for( s = bu->ic->acc->tag; isalnum( (unsigned char)*s ); s ++ );
 			/* Only use the tag if we got to the end of the string.
 			   (So allow alphanumerics only. Hopefully not too
 			   restrictive.) */
@@ -315,7 +315,7 @@ static gboolean bee_irc_user_fullname( bee_t *bee, bee_user_t *bu )
 	/* Strip newlines (unlikely, but IRC-unfriendly so they must go)
 	   TODO(wilmer): Do the same with away msgs again! */
 	for( s = iu->fullname; *s; s ++ )
-		if( isspace( *s ) ) *s = ' ';
+		if( isspace( (unsigned char)*s ) ) *s = ' ';
 	
 	if( ( bu->ic->flags & OPT_LOGGED_IN ) && set_getbool( &bee->set, "display_namechanges" ) )
 	{

--- a/irc_util.c
+++ b/irc_util.c
@@ -41,9 +41,9 @@ char *set_eval_timezone( set_t *set, char *value )
 		s ++;
 	
 	/* \d+ */
-	if( !isdigit( *s ) )
+	if( !isdigit( (unsigned char)*s ) )
 		return SET_INVALID;
-	while( *s && isdigit( *s ) ) s ++;
+	while( *s && isdigit( (unsigned char)*s ) ) s ++;
 	
 	/* EOS? */
 	if( *s == '\0' )
@@ -55,9 +55,9 @@ char *set_eval_timezone( set_t *set, char *value )
 	s ++;
 	
 	/* \d+ */
-	if( !isdigit( *s ) )
+	if( !isdigit( (unsigned char)*s ) )
 		return SET_INVALID;
-	while( *s && isdigit( *s ) ) s ++;
+	while( *s && isdigit( (unsigned char)*s ) ) s ++;
 	
 	/* EOS */
 	return *s == '\0' ? value : SET_INVALID;

--- a/lib/http_client.c
+++ b/lib/http_client.c
@@ -338,12 +338,12 @@ static http_ret_t http_process_chunked_data( struct http_request *req, const cha
 		
 		/* Might be a \r\n from the last chunk. */
 		s = chunk;
-		while( isspace( *s ) )
+		while( isspace( (unsigned char)*s ) )
 			s ++;
 		/* Chunk length. Might be incomplete. */
 		if( s < eos && sscanf( s, "%x", &clen ) != 1 )
 			return CR_ERROR;
-		while( isxdigit( *s ) )
+		while( isxdigit( (unsigned char)*s ) )
 			s ++;
 		
 		/* If we read anything here, it *must* be \r\n. */

--- a/lib/ini.c
+++ b/lib/ini.c
@@ -62,11 +62,11 @@ static char *ini_strip_whitespace( char *in )
 {
 	char *e;
 
-	while( isspace( *in ) )
+	while( isspace( (unsigned char)*in ) )
 		in++;
 
 	e = in + strlen( in ) - 1;
-	while( e > in && isspace( *e ) )
+	while( e > in && isspace( (unsigned char)*e ) )
 		e--;
 	e[1] = 0;
 	

--- a/lib/json.c
+++ b/lib/json.c
@@ -52,7 +52,7 @@ typedef unsigned int json_uchar;
 
 static unsigned char hex_value (json_char c)
 {
-   if (isdigit(c))
+   if (isdigit((unsigned char)c))
       return c - '0';
 
    switch (c) {
@@ -608,14 +608,14 @@ json_value * json_parse_ex (json_settings * settings,
 
                      default:
 
-                        if (isdigit (b) || b == '-')
+                        if (isdigit ((unsigned char)b) || b == '-')
                         {
                            if (!new_value (&state, &top, &root, &alloc, json_integer))
                               goto e_alloc_failure;
 
                            if (!state.first_pass)
                            {
-                              while (isdigit (b) || b == '+' || b == '-'
+                              while (isdigit ((unsigned char)b) || b == '+' || b == '-'
                                         || b == 'e' || b == 'E' || b == '.')
                               {
                                  if ( (++ i) == end)
@@ -705,7 +705,7 @@ json_value * json_parse_ex (json_settings * settings,
             case json_integer:
             case json_double:
 
-               if (isdigit (b))
+               if (isdigit ((unsigned char)b))
                {
                   ++ num_digits;
 

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -162,7 +162,7 @@ void strip_html( char *in )
 	
 	while( *in )
 	{
-		if( *in == '<' && ( isalpha( *(in+1) ) || *(in+1) == '/' ) )
+		if( *in == '<' && ( isalpha( (unsigned char)*(in+1) ) || *(in+1) == '/' ) )
 		{
 			/* If in points at a < and in+1 points at a letter or a slash, this is probably
 			   a HTML-tag. Try to find a closing > and continue there. If the > can't be
@@ -197,7 +197,7 @@ void strip_html( char *in )
 		else if( *in == '&' )
 		{
 			cs = ++in;
-			while( *in && isalpha( *in ) )
+			while( *in && isalpha( (unsigned char)*in ) )
 				in ++;
 			
 			if( *in == ';' ) in ++;
@@ -491,7 +491,7 @@ int is_bool( char *value )
 		return 1;
 	
 	while( *value )
-		if( !isdigit( *value ) )
+		if( !isdigit( (unsigned char)*value ) )
 			return 0;
 		else
 			value ++;

--- a/lib/ns_parse.c
+++ b/lib/ns_parse.c
@@ -18,7 +18,7 @@
 #include "bitlbee.h"
 
 #ifndef lint
-static const char rcsid[] = "$Id: ns_parse.c,v 1.10 2009/01/23 19:59:16 each Exp $";
+//static const char rcsid[] = "$Id: ns_parse.c,v 1.10 2009/01/23 19:59:16 each Exp $";
 #endif
 
 #ifdef HAVE_RESOLV_A

--- a/lib/proxy.c
+++ b/lib/proxy.c
@@ -71,7 +71,7 @@ static int proxy_connect_none(const char *host, unsigned short port_, struct PHB
 static gboolean gaim_io_connected(gpointer data, gint source, b_input_condition cond)
 {
 	struct PHB *phb = data;
-	unsigned int len;
+	socklen_t len;
 	int error = ETIMEDOUT;
 	len = sizeof(error);
 	
@@ -221,7 +221,7 @@ static gboolean http_canwrite(gpointer data, gint source, b_input_condition cond
 {
 	char cmd[384];
 	struct PHB *phb = data;
-	unsigned int len;
+	socklen_t len;
 	int error = ETIMEDOUT;
 	if (phb->inpa > 0)
 		b_event_remove(phb->inpa);
@@ -316,7 +316,7 @@ static gboolean s4_canwrite(gpointer data, gint source, b_input_condition cond)
 	unsigned char packet[12];
 	struct hostent *hp;
 	struct PHB *phb = data;
-	unsigned int len;
+	socklen_t len;
 	int error = ETIMEDOUT;
 	if (phb->inpa > 0)
 		b_event_remove(phb->inpa);
@@ -508,7 +508,7 @@ static gboolean s5_canwrite(gpointer data, gint source, b_input_condition cond)
 	unsigned char buf[512];
 	int i;
 	struct PHB *phb = data;
-	unsigned int len;
+	socklen_t len;
 	int error = ETIMEDOUT;
 	if (phb->inpa > 0)
 		b_event_remove(phb->inpa);

--- a/lib/ssl_gnutls.c
+++ b/lib/ssl_gnutls.c
@@ -317,7 +317,7 @@ static gboolean ssl_connected( gpointer data, gint source, b_input_condition con
 #endif
 	gnutls_set_default_priority( conn->session );
 	gnutls_credentials_set( conn->session, GNUTLS_CRD_CERTIFICATE, xcred );
-	if( conn->hostname && !isdigit( conn->hostname[0] ) )
+	if( conn->hostname && !isdigit( (unsigned char)conn->hostname[0] ) )
 		gnutls_server_name_set( conn->session, GNUTLS_NAME_DNS,
 		                        conn->hostname, strlen( conn->hostname ) );
 	

--- a/nick.c
+++ b/nick.c
@@ -40,7 +40,7 @@ static char *clean_handle( const char *orig )
 	
 	do {
 		if (*orig != ' ')
-			new[i++] = tolower( *orig );
+			new[i++] = tolower( (unsigned int)*orig );
 	}
 	while (*(orig++));
 	
@@ -143,11 +143,11 @@ char *nick_gen( bee_user_t *bu )
 				}
 				fmt += 2;
 			}
-			else if( isdigit( *fmt ) )
+			else if( isdigit( (unsigned char)*fmt ) )
 			{
 				len = 0;
 				/* Grab a number. */
-				while( isdigit( *fmt ) )
+				while( isdigit( (unsigned char)*fmt ) )
 					len = len * 10 + ( *(fmt++) - '0' );
 			}
 			else if( g_strncasecmp( fmt, "nick", 4 ) == 0 )
@@ -330,7 +330,7 @@ void nick_strip( irc_t *irc, char *nick )
 			}
 		}
 	}
-	if( isdigit( nick[0] ) )
+	if( isdigit( (unsigned char)nick[0] ) )
 	{
 		char *orig;
 		
@@ -350,7 +350,7 @@ gboolean nick_ok( irc_t *irc, const char *nick )
 	const char *s;
 	
 	/* Empty/long nicks are not allowed, nor numbers at [0] */
-	if( !*nick || isdigit( nick[0] ) || strlen( nick ) > MAX_NICK_LENGTH )
+	if( !*nick || isdigit( (unsigned char)nick[0] ) || strlen( nick ) > MAX_NICK_LENGTH )
 		return 0;
 	
 	if( irc && ( irc->status & IRC_UTF8_NICKS ) )

--- a/protocols/account.c
+++ b/protocols/account.c
@@ -80,7 +80,7 @@ account_t *account_add( bee_t *bee, struct prpl *prpl, char *user, char *pass )
 	strcpy( tag, prpl->name );
 	if( strcmp( prpl->name, "oscar" ) == 0 )
 	{
-		if( isdigit( a->user[0] ) )
+		if( isdigit( (unsigned char)a->user[0] ) )
 			strcpy( tag, "icq" );
 		else
 			strcpy( tag, "aim" );
@@ -416,7 +416,7 @@ int account_reconnect_delay_parse( char *value, struct account_reconnect_delay *
 	p->max = 86400;
 	
 	/* Format: /[0-9]+([*+][0-9]+(<[0-9+])?)?/ */
-	while( *value && isdigit( *value ) )
+	while( *value && isdigit( (unsigned char)*value ) )
 		p->start = p->start * 10 + *value++ - '0';
 	
 	/* Sure, call me evil for implementing my own fscanf here, but it's
@@ -432,7 +432,7 @@ int account_reconnect_delay_parse( char *value, struct account_reconnect_delay *
 	p->op = *value++;
 	
 	/* + or * the delay by this number every time. */
-	while( *value && isdigit( *value ) )
+	while( *value && isdigit( (unsigned char)*value ) )
 		p->step = p->step * 10 + *value++ - '0';
 	
 	if( *value == 0 )
@@ -443,7 +443,7 @@ int account_reconnect_delay_parse( char *value, struct account_reconnect_delay *
 	
 	p->max = 0;
 	value ++;
-	while( *value && isdigit( *value ) )
+	while( *value && isdigit( (unsigned char)*value ) )
 		p->max = p->max * 10 + *value++ - '0';
 	
 	return p->max > 0;

--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -320,7 +320,7 @@ int jabber_compare_jid( const char *jid1, const char *jid2 )
 				break;
 			return FALSE;
 		}
-		if( tolower( jid1[i] ) != tolower( jid2[i] ) )
+		if( tolower( (unsigned int)jid1[i] ) != tolower( (unsigned int)jid2[i] ) )
 		{
 			return FALSE;
 		}
@@ -341,7 +341,7 @@ char *jabber_normalize( const char *orig )
 	/* So it turns out the /resource part is case sensitive. Yeah, and
 	   it's Unicode but feck Unicode. :-P So stop once we see a slash. */
 	for( i = 0; i < len && orig[i] != '/' ; i ++ )
-		new[i] = tolower( orig[i] );
+		new[i] = tolower( (unsigned int)orig[i] );
 	for( ; orig[i]; i ++ )
 		new[i] = orig[i];
 	

--- a/protocols/jabber/sasl.c
+++ b/protocols/jabber/sasl.c
@@ -203,7 +203,7 @@ char *sasl_get_part( char *data, char *field )
 	
 	len = strlen( field );
 	
-	while( isspace( *data ) || *data == ',' )
+	while( isspace( (unsigned char)*data ) || *data == ',' )
 		data ++;
 	
 	if( g_strncasecmp( data, field, len ) == 0 && data[len] == '=' )
@@ -226,7 +226,7 @@ char *sasl_get_part( char *data, char *field )
 			   find the next key after it. */
 			if( data[i] == ',' )
 			{
-				while( isspace( data[i] ) || data[i] == ',' )
+				while( isspace( (unsigned char)data[i] ) || data[i] == ',' )
 					i ++;
 				
 				if( g_strncasecmp( data + i, field, len ) == 0 &&

--- a/protocols/msn/msn.c
+++ b/protocols/msn/msn.c
@@ -368,7 +368,7 @@ static void msn_buddy_data_add( bee_user_t *bu )
 	bd = bu->data = g_new0( struct msn_buddy_data, 1 );
 	g_tree_insert( md->domaintree, bu->handle, bu );
 	
-	for( handle = bu->handle; isdigit( *handle ); handle ++ );
+	for( handle = bu->handle; isdigit( (unsigned char)*handle ); handle ++ );
 	if( *handle == ':' )
 	{
 		/* Pass a nick hint so hopefully the stupid numeric prefix

--- a/protocols/msn/ns.c
+++ b/protocols/msn/ns.c
@@ -580,7 +580,7 @@ static int msn_ns_command( struct msn_handler_data *handler, char **cmd, int num
 	{
 		ic->flags |= OPT_PONGED;
 	}
-	else if( isdigit( cmd[0][0] ) )
+	else if( isdigit( (unsigned char)cmd[0][0] ) )
 	{
 		int num = atoi( cmd[0] );
 		const struct msn_status_code *err = msn_status_by_number( num );
@@ -996,7 +996,7 @@ int msn_ns_sendmessage( struct im_connection *ic, bee_user_t *bu, const char *te
 	
 	/* This might be a federated contact. Get its network number,
 	   prefixed to bu->handle with a colon. Default is 1. */
-	for( handle = bu->handle; isdigit( *handle ); handle ++ )
+	for( handle = bu->handle; isdigit( (unsigned char)*handle ); handle ++ )
 		type = type * 10 + *handle - '0';
 	if( *handle == ':' )
 		handle ++;

--- a/protocols/msn/sb.c
+++ b/protocols/msn/sb.c
@@ -505,7 +505,7 @@ static int msn_sb_command( struct msn_handler_data *handler, char **cmd, int num
 	}
 	else if( strcmp( cmd[0], "CAL" ) == 0 )
 	{
-		if( num_parts < 4 || !isdigit( cmd[3][0] ) )
+		if( num_parts < 4 || !isdigit( (unsigned char)cmd[3][0] ) )
 		{
 			msn_sb_destroy( sb );
 			return( 0 );
@@ -644,7 +644,7 @@ static int msn_sb_command( struct msn_handler_data *handler, char **cmd, int num
 			/* PANIC! */
 		}
 	}
-	else if( isdigit( cmd[0][0] ) )
+	else if( isdigit( (unsigned char)cmd[0][0] ) )
 	{
 		int num = atoi( cmd[0] );
 		const struct msn_status_code *err = msn_status_by_number( num );

--- a/protocols/oscar/auth.c
+++ b/protocols/oscar/auth.c
@@ -124,7 +124,7 @@ int aim_request_login(aim_session_t *sess, aim_conn_t *conn, const char *sn)
 	if (!sess || !conn || !sn)
 		return -EINVAL;
 
-	if (isdigit(sn[0]) && set_getbool(&ic->acc->set, "old_icq_auth"))
+	if (isdigit((unsigned char)sn[0]) && set_getbool(&ic->acc->set, "old_icq_auth"))
 		return goddamnicq(sess, conn, sn);
 
 	sess->flags |= AIM_SESS_FLAGS_SNACLOGIN;

--- a/protocols/oscar/conn.c
+++ b/protocols/oscar/conn.c
@@ -570,7 +570,7 @@ int aim_conn_completeconnect(aim_session_t *sess, aim_conn_t *conn)
 	} 
 
 	if (FD_ISSET(conn->fd, &fds) || FD_ISSET(conn->fd, &wfds)) {
-		unsigned int len = sizeof(error);
+		socklen_t len = sizeof(error);
 
 		if (getsockopt(conn->fd, SOL_SOCKET, SO_ERROR, &error, &len) < 0)
 			error = errno;

--- a/protocols/oscar/oscar.c
+++ b/protocols/oscar/oscar.c
@@ -367,7 +367,7 @@ static gboolean oscar_login_connect(gpointer data, gint source, b_input_conditio
 static void oscar_init(account_t *acc)
 {
 	set_t *s;
-	gboolean icq = isdigit(acc->user[0]);
+	gboolean icq = isdigit((unsigned char)acc->user[0]);
 	
 	if (icq) {
 		set_add(&acc->set, "ignore_auth_requests", "false", set_eval_bool, acc);
@@ -393,7 +393,7 @@ static void oscar_login(account_t *acc) {
 	struct im_connection *ic = imcb_new(acc);
 	struct oscar_data *odata = ic->proto_data = g_new0(struct oscar_data, 1);
 
-	if (isdigit(acc->user[0]))
+	if (isdigit((unsigned char)acc->user[0]))
 		odata->icq = TRUE;
 	else
 		ic->flags |= OPT_DOES_HTML;
@@ -2499,11 +2499,11 @@ struct groupchat *oscar_chat_with(struct im_connection * ic, char *who)
 	static int chat_id = 0;
 	char * chatname, *s;
 	
-	chatname = g_strdup_printf("%s%s%d", isdigit(*ic->acc->user) ? "icq" : "",
+	chatname = g_strdup_printf("%s%s%d", isdigit((unsigned char)*ic->acc->user) ? "icq" : "",
 	                           ic->acc->user, chat_id++);
 	
 	for (s = chatname; *s; s ++)
-		if (!isalnum(*s))
+		if (!isalnum((unsigned char)*s))
 			*s = '0';
 	
 	ret = oscar_chat_join_internal(ic, chatname, NULL, NULL, 4);

--- a/protocols/oscar/oscar_util.c
+++ b/protocols/oscar/oscar_util.c
@@ -56,7 +56,7 @@ int aim_sncmp(const char *sn1, const char *sn2)
 			if (*curPtr2 == ' ')
 				curPtr2++;
 		} else {
-			if ( toupper(*curPtr1) != toupper(*curPtr2))
+			if ( toupper((unsigned int)*curPtr1) != toupper((unsigned int)*curPtr2))
 				return 1;
 			curPtr1++;
 			curPtr2++;

--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -467,9 +467,9 @@ static int twitter_buddy_msg(struct im_connection *ic, char *who, char *message,
 			char pin[strlen(message) + 1], *s;
 
 			strcpy(pin, message);
-			for (s = pin + sizeof(pin) - 2; s > pin && isspace(*s); s--)
+			for (s = pin + sizeof(pin) - 2; s > pin && isspace((unsigned char)*s); s--)
 				*s = '\0';
-			for (s = pin; *s && isspace(*s); s++) {
+			for (s = pin; *s && isspace((unsigned char)*s); s++) {
 			}
 
 			if (!oauth_access_token(s, td->oauth_info)) {

--- a/protocols/yahoo/libyahoo2.c
+++ b/protocols/yahoo/libyahoo2.c
@@ -960,7 +960,8 @@ static void yahoo_process_conference(struct yahoo_input_data *yid,
 		if (pair->key == 14)	/* decline/conf message */
 			msg = pair->value;
 
-		if (pair->key == 13) ;
+		if (pair->key == 13) 
+			;
 		if (pair->key == 16)	/* error */
 			msg = pair->value;
 
@@ -1781,9 +1782,9 @@ static enum yahoo_status yahoo_https_status_parse(int code)
 {
 	switch (code)
 	{
-		case 1212: return YAHOO_LOGIN_PASSWD;
-		case 1213: return YAHOO_LOGIN_LOCK;
-		case 1235: return YAHOO_LOGIN_UNAME;
+		case 1212: return (enum yahoo_status) YAHOO_LOGIN_PASSWD;
+		case 1213: return (enum yahoo_status) YAHOO_LOGIN_LOCK;
+		case 1235: return (enum yahoo_status) YAHOO_LOGIN_UNAME;
 		default: return (enum yahoo_status) code;
 	}
 }
@@ -3596,7 +3597,7 @@ void yahoo_send_im(int id, const char *from, const char *who, const char *what,
 
 	yd = yid->yd;
 
-	pkt = yahoo_packet_new(YAHOO_SERVICE_MESSAGE, YAHOO_STATUS_OFFLINE,
+	pkt = yahoo_packet_new(YAHOO_SERVICE_MESSAGE, (enum ypacket_status) YAHOO_STATUS_OFFLINE,
 		yd->session_id);
 
 	snprintf(pic_str, sizeof(pic_str), "%d", picture);
@@ -3663,7 +3664,7 @@ void yahoo_set_away(int id, enum yahoo_status state, const char *msg, int away)
 	/* Thank you libpurple :) */
 	if (yd->current_status == YAHOO_STATUS_INVISIBLE) {
 		pkt = yahoo_packet_new(YAHOO_SERVICE_Y6_VISIBLE_TOGGLE,
-			YAHOO_STATUS_AVAILABLE, 0);
+			(enum ypacket_status) YAHOO_STATUS_AVAILABLE, 0);
 		yahoo_packet_hash(pkt, 13, "2");
 		yahoo_send_packet(yid, pkt, 0);
 		yahoo_packet_free(pkt);
@@ -3682,7 +3683,7 @@ void yahoo_set_away(int id, enum yahoo_status state, const char *msg, int away)
 
 	if (old_status == YAHOO_STATUS_INVISIBLE) {
 		pkt = yahoo_packet_new(YAHOO_SERVICE_Y6_VISIBLE_TOGGLE,
-			YAHOO_STATUS_AVAILABLE, 0);
+			(enum ypacket_status) YAHOO_STATUS_AVAILABLE, 0);
 		yahoo_packet_hash(pkt, 13, "1");
 		yahoo_send_packet(yid, pkt, 0);
 		yahoo_packet_free(pkt);

--- a/protocols/yahoo/yahoo_util.h
+++ b/protocols/yahoo/yahoo_util.h
@@ -47,6 +47,9 @@
 # endif
 
 # define snprintf	g_snprintf
+#ifdef vsnprintf
+#undef vsnprintf
+#endif
 # define vsnprintf	g_vsnprintf
 
 #else

--- a/set.c
+++ b/set.c
@@ -225,7 +225,7 @@ char *set_eval_int( set_t *set, char *value )
 		s ++;
 	
 	for( ; *s; s ++ )
-		if( !isdigit( *s ) )
+		if( !isdigit( (unsigned char)*s ) )
 			return SET_INVALID;
 	
 	return value;

--- a/tests/check_arc.c
+++ b/tests/check_arc.c
@@ -87,6 +87,8 @@ static void check_decod(int l)
 		len = arc_decode( decrypt_tests[i].crypted, decrypt_tests[i].len,
 		                  &decrypted, password );
 		
+		fail_if( len == -1, 
+                 "`%s' didn't decrypt properly", decrypt_tests[i].decrypted );
 		fail_if( strcmp( decrypt_tests[i].decrypted, decrypted ) != 0,
 		         "`%s' didn't decrypt properly", decrypt_tests[i].decrypted );
 		

--- a/tests/check_irc.c
+++ b/tests/check_irc.c
@@ -27,7 +27,6 @@ END_TEST
 START_TEST(test_login)
 	GIOChannel *ch1, *ch2;
 	irc_t *irc;
-	GError *error = NULL;
 	char *raw;
 	fail_unless(g_io_channel_pair(&ch1, &ch2));
 

--- a/tests/check_jabber_sasl.c
+++ b/tests/check_jabber_sasl.c
@@ -86,7 +86,6 @@ static void check_get_part(int l)
 	{
   		tcase_fn_start( get_part_tests[i].key, __FILE__, i );
 		char *res;
-		int len;
 		
 		res = sasl_get_part( get_part_tests[i].challenge,
 		                     get_part_tests[i].key );


### PR DESCRIPTION
- Don't use PIE/PIC on Cygwin/Darwin unless specified as these
  platforms don't support it.
- Cleanup warnings for 'make check' build.
- Fix a bunch of isdidigt/isalpha/etc. type warnings about char subscripts.
  Based on the recommendation of http://stackoverflow.com/a/10186479/89101
  they now all contain casts to usigned char.
- Fix the type issue for gesockopt calls.
- Fix enum warnings in Yahoo libs on Mac OS X.
