### PR TITLE
[review] From trac: Support for Jabber XEP-0280, "Carbons"

### DIFF
--- a/protocols/bee.h
+++ b/protocols/bee.h
@@ -107,7 +107,7 @@ typedef struct bee_ui_funcs
 	/* State info is already updated, old is provided in case the UI needs a diff. */
 	gboolean (*user_status)( bee_t *bee, struct bee_user *bu, struct bee_user *old );
 	/* On every incoming message. sent_at = 0 means unknown. */
-	gboolean (*user_msg)( bee_t *bee, bee_user_t *bu, const char *msg, time_t sent_at );
+	gboolean (*user_msg)( bee_t *bee, bee_user_t *bu, const char *msg, time_t sent_at, guint32 flags );
 	/* Flags currently defined (OPT_TYPING/THINKING) in nogaim.h. */
 	gboolean (*user_typing)( bee_t *bee, bee_user_t *bu, guint32 flags );
 	/* CTCP-like stuff (buddy action) response */
@@ -131,7 +131,6 @@ typedef struct bee_ui_funcs
 	void (*ft_close)( struct im_connection *ic, struct file_transfer *ft );
 	void (*ft_finished)( struct im_connection *ic, struct file_transfer *ft );
 } bee_ui_funcs_t;
-
 
 /* bee.c */
 bee_t *bee_new();

--- a/protocols/bee_user.c
+++ b/protocols/bee_user.c
@@ -265,7 +265,7 @@ void imcb_buddy_msg( struct im_connection *ic, const char *handle, char *msg, ui
 	}
 	
 	if( bee->ui->user_msg && bu )
-		bee->ui->user_msg( bee, bu, msg, sent_at );
+		bee->ui->user_msg( bee, bu, msg, sent_at, flags );
 	else
 		imcb_log( ic, "Message from unknown handle %s:\n%s", handle, msg );
 }

--- a/protocols/jabber/jabber.h
+++ b/protocols/jabber/jabber.h
@@ -47,6 +47,9 @@ typedef enum
 	JFLAG_XMLCONSOLE = 64,          /* If the user added an xmlconsole buddy. */
 	JFLAG_STARTTLS_DONE = 128,      /* If a plaintext session was converted to TLS. */
 
+	JFLAG_CARBONS_SUPPORT = 256,    /* If server supports XEP-0280. */
+	JFLAG_CARBONS_ENABLED = 512,    /* If server supports XEP-0280. */
+
 	JFLAG_GTALK =  0x100000,        /* Is Google Talk, as confirmed by iq discovery */
 
 	JFLAG_SASL_FB = 0x10000,        /* Trying Facebook authentication. */
@@ -231,6 +234,8 @@ struct jabber_transfer
 #define XMLNS_DELAY_OLD    "jabber:x:delay"                                      /* XEP-0091 */
 #define XMLNS_DELAY        "urn:xmpp:delay"                                      /* XEP-0203 */
 #define XMLNS_XDATA        "jabber:x:data"                                       /* XEP-0004 */
+#define XMLNS_CARBONS      "urn:xmpp:carbons:2"                                  /* XEP-0280 */
+#define XMLNS_FORWARDING   "urn:xmpp:forward:0"                                  /* XEP-0297 */
 #define XMLNS_CHATSTATES   "http://jabber.org/protocol/chatstates"               /* XEP-0085 */
 #define XMLNS_DISCO_INFO   "http://jabber.org/protocol/disco#info"               /* XEP-0030 */
 #define XMLNS_DISCO_ITEMS  "http://jabber.org/protocol/disco#items"              /* XEP-0030 */

--- a/protocols/nogaim.h
+++ b/protocols/nogaim.h
@@ -69,6 +69,7 @@
 #define OPT_NOOTR       0x00001000 /* protocol not suitable for OTR */
 #define OPT_PONGS       0x00010000 /* Service sends us keep-alives */
 #define OPT_PONGED      0x00020000 /* Received a keep-alive during last interval */
+#define OPT_CARBONS_SENT 0x00040000 /* Message is a Carbons forward */
 
 /* ok. now the fun begins. first we create a connection structure */
 struct im_connection


### PR DESCRIPTION
Patch by `Stephen Shirley <kormat@gmail.com>` (`kormat` on irc) from trac

Ticket: http://bugs.bitlbee.org/bitlbee/ticket/1021

Specification: http://xmpp.org/extensions/xep-0280.html

tl;dr: Carbons is an XMPP extension that lets clients receive messages sent by other clients connected to the same account. Basically support for multiple locations that makes sense to most people, unlike the old 'resources' concept.

Notes by patch author:

> I have written a patch against bzr rev 994 (bitlbee 3.2.0) that adds Carbons support. My C is a bit rusty, and i'm new to the codebase, so careful review and feedback requested :)
> 
> A few comments on my implementation:
> - I'm looking for feedback before i go any further, but right support is functionally complete
> - Tested using prosody 0.8.2 (but with carbons support taken from 0.9.0rc) and irssi 0.8.15.
> - It queries for carbons support and automatically enables it if present. This should probably be a setting.
> - IRC doesn't provide a way for the server to tell the client "hi, you sent this message", so displaying forwarded messages that you have sent from another client is non-trivial. I've worked around this by hacking NOTICEs. It's definitely not pretty, but is the least bad way i can find. This definitely needs testing on other irc clients, and almost certainly needs a setting to customize how this display is done. 
> 
> For anyone who wants to review/test this patch, i'm happy to give you an account on my jabber server which has carbons support. Just let me know.
