### PR TITLE
[review] Signal handlers cleanup

### DIFF
--- a/bitlbee.c
+++ b/bitlbee.c
@@ -361,10 +361,12 @@ static gboolean bitlbee_io_new_client( gpointer data, gint fd, b_input_condition
 
 gboolean bitlbee_shutdown( gpointer data, gint fd, b_input_condition cond )
 {
+	/* Send the message here with now=TRUE to ensure it arrives */
+	irc_write_all( TRUE, "ERROR :Closing link: BitlBee server shutting down" );
+
 	/* Try to save data for all active connections (if desired). */
 	while( irc_connection_list != NULL )
-		irc_abort( irc_connection_list->data, TRUE,
-		           "BitlBee server shutting down" );
+		irc_abort( irc_connection_list->data, TRUE, NULL );
 	
 	/* We'll only reach this point when not running in inetd mode: */
 	b_main_quit();


### PR DESCRIPTION
Calling log_message() inside a signal handler is unsafe [because it includes calls to malloc()](http://stackoverflow.com/questions/3366307/why-is-malloc-not-async-signal-safe). See also [this very nice page](https://www.securecoding.cert.org/confluence/display/seccode/SIG30-C.+Call+only+asynchronous-safe+functions+within+signal+handlers)

This removes most of those log_message() calls, replacing them with safe logging instead when required.

WIP. Considering adding fancy stack traces to it. May be squashed later.
