### PR TITLE
[review] Use glib functions for base64 decoding/encoding

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -26,8 +26,6 @@
 #include <string.h>
 #include "base64.h"
 
-static const char real_b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-
 char *tobase64(const char *text)
 {
 	return base64_encode((const unsigned char *)text, strlen(text));
@@ -35,48 +33,7 @@ char *tobase64(const char *text)
 
 char *base64_encode(const unsigned char *in, int len)
 {
-	char *out;
-	
-	out = g_malloc((len + 2)    /* the == padding */
-	                    / 3     /* every 3-byte block */
-	                    * 4     /* becomes a 4-byte one */
-	                    + 1);   /* and of course, ASCIIZ! */
-	
-	base64_encode_real((unsigned char*) in, len, (unsigned char*) out, real_b64);
-	
-	return out;
-}
-
-int base64_encode_real(const unsigned char *in, int inlen, unsigned char *out, const char *b64digits)
-{
-	int outlen = 0;
-	
-	for (; inlen >= 3; inlen -= 3)
-	{
-		out[outlen++] = b64digits[in[0] >> 2];
-		out[outlen++] = b64digits[((in[0]<<4) & 0x30) | (in[1]>>4)];
-		out[outlen++] = b64digits[((in[1]<<2) & 0x3c) | (in[2]>>6)];
-		out[outlen++] = b64digits[in[2] & 0x3f];
-		in += 3;
-	}
-	if (inlen > 0)
-	{
-		out[outlen++] = b64digits[in[0] >> 2];
-		if (inlen > 1)
-		{
-			out[outlen++] = b64digits[((in[0]<<4) & 0x30) | (in[1]>>4)];
-			out[outlen++] = b64digits[((in[1]<<2) & 0x3c)];
-		}
-		else
-		{
-			out[outlen++] = b64digits[((in[0]<<4) & 0x30)];
-			out[outlen++] = b64digits[64];
-		}
-		out[outlen++] = b64digits[64];
-	}
-	out[outlen] = 0;
-	
-	return outlen;
+	return g_base64_encode(in, len);
 }
 
 /* Just a simple wrapper, but usually not very convenient because of zero
@@ -84,70 +41,18 @@ int base64_encode_real(const unsigned char *in, int inlen, unsigned char *out, c
 char *frombase64(const char *in)
 {
 	unsigned char *out;
-	
 	base64_decode(in, &out);
-	
 	return (char*) out;
 }
 
-/* FIXME: Lookup table stuff is not threadsafe! (But for now BitlBee is not threaded.) */
 int base64_decode(const char *in, unsigned char **out)
 {
-	static char b64rev[256] = { 0 };
-	int len, i;
-	
-	/* Create a reverse-lookup for the Base64 sequence. */
-	if( b64rev[0] == 0 )
-	{
-		memset( b64rev, 0xff, 256 );
-		for( i = 0; i <= 64; i ++ )
-			b64rev[(int)real_b64[i]] = i;
-	}
-	
-	len = strlen( in );
-	*out = g_malloc( ( len + 6 ) / 4 * 3 );
-	len = base64_decode_real( (unsigned char*) in, *out, b64rev );
-	*out = g_realloc( *out, len + 1 );
-	out[0][len] = 0;	/* Zero termination can't hurt. */
-	
-	return len;
-}
+	gsize len;
+	*out = g_base64_decode(in, &len);
 
-int base64_decode_real(const unsigned char *in, unsigned char *out, char *b64rev)
-{
-	int i, outlen = 0;
-	
-	for( i = 0; in[i] && in[i+1] && in[i+2] && in[i+3]; i += 4 )
-	{
-		int sx;
-		
-		sx = b64rev[(int)in[i+0]];
-		if( sx >= 64 )
-			break;
-		out[outlen] = ( sx << 2 ) & 0xfc;
-		
-		sx = b64rev[(int)in[i+1]];
-		if( sx >= 64 )
-			break;
-		out[outlen] |= ( sx >> 4 ) & 0x03;
-		outlen ++;
-		out[outlen] = ( sx << 4 ) & 0xf0;
-		
-		sx = b64rev[(int)in[i+2]];
-		if( sx >= 64 )
-			break;
-		out[outlen] |= ( sx >> 2 ) & 0x0f;
-		outlen ++;
-		out[outlen] = ( sx << 6 ) & 0xc0;
-		
-		sx = b64rev[(int)in[i+3]];
-		if( sx >= 64 )
-			break;
-		out[outlen] |= sx;
-		outlen ++;
-	}
-	
-	/* If sx > 64 the base64 string was damaged. Should we ignore this? */
-	
-	return outlen;
+	/* Some silly functions expect it to be zero terminated */
+	*out = g_realloc(*out, len + 1);
+	out[0][len] = 0;
+
+	return len;
 }

--- a/lib/base64.h
+++ b/lib/base64.h
@@ -27,7 +27,5 @@
 
 G_MODULE_EXPORT char *tobase64( const char *text );
 G_MODULE_EXPORT char *base64_encode( const unsigned char *in, int len );
-G_MODULE_EXPORT int base64_encode_real( const unsigned char *in, int inlen, unsigned char *out, const char *b64digits );
 G_MODULE_EXPORT char *frombase64( const char *in );
 G_MODULE_EXPORT int base64_decode( const char *in, unsigned char **out );
-G_MODULE_EXPORT int base64_decode_real( const unsigned char *in, unsigned char *out, char *b64reverse );

--- a/lib/oauth.c
+++ b/lib/oauth.c
@@ -75,13 +75,8 @@ static char *oauth_sign( const char *method, const char *url,
 static char *oauth_nonce()
 {
 	unsigned char bytes[21];
-	char *ret = g_new0( char, sizeof( bytes) / 3 * 4 + 1 );
-	
 	random_bytes( bytes, sizeof( bytes ) );
-	base64_encode_real( bytes, sizeof( bytes), (unsigned char*) ret, "0123456789"
-	                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0A" );
-	
-	return ret;
+	return base64_encode( bytes, sizeof( bytes ) );
 }
 
 void oauth_params_add( GSList **params, const char *key, const char *value )

--- a/protocols/yahoo/libyahoo2.c
+++ b/protocols/yahoo/libyahoo2.c
@@ -680,10 +680,25 @@ static void yahoo_packet_dump(unsigned char *data, int len)
 	}
 }
 
-/* raw bytes in quasi-big-endian order to base 64 string (NUL-terminated) */
+/* yahoo's variant of base64 */
 static void to_y64(unsigned char *out, const unsigned char *in, int inlen)
 {
-	base64_encode_real(in, inlen, out, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-");
+	char *encoded = base64_encode(in, inlen);
+	int i = 0;
+
+	do {
+		if (encoded[i] == '+') {
+			out[i] = '.';
+		} else if (encoded[i] == '/') {
+			out[i] = '_';
+		} else if (encoded[i] == '=') {
+			out[i] = '-';
+		} else {
+			out[i] = encoded[i];
+		}
+	} while (encoded[i++]);
+
+	g_free(encoded);
 }
 
 static void yahoo_add_to_send_queue(struct yahoo_input_data *yid, void *data,


### PR DESCRIPTION
This fixes several coverity warnings about 'tainted data index sink' and a fixme about thread safety in the old base64_decode implementation.

Had to adapt the code that used base64_encode_real:
- oauth.c: different character set order, but it's for the nonce so it doesn't matter
- libyahoo2.c: used as part of the auth, changes "+/=" into "._-". Fixed by encoding first the usual way through glib, then replacing.

---

The only thing that needs review here, IMO, is the to_y64 function of libyahoo2.c. It works, just looking for opinions on the way I did that char replacement. I think this is cleaner than a switch(), but eh.
