### PR TITLE
Twitter search channels 2: it's back for revenge

### DIFF
--- a/protocols/twitter/twitter.c
+++ b/protocols/twitter/twitter.c
@@ -119,6 +119,8 @@ void twitter_login_finish(struct im_connection *ic)
 		twitter_get_friends_ids(ic, -1);
 	} else
 		twitter_main_loop_start(ic);
+
+	twitter_tracking_stream(ic);
 }
 
 static const struct oauth_service twitter_oauth = {
@@ -427,7 +429,14 @@ static void twitter_logout(struct im_connection *ic)
 	if (td->timeline_gc)
 		imcb_chat_free(td->timeline_gc);
 
+	if (td->hashtag_chats)
+		g_slist_free_full(td->hashtag_chats, (GDestroyNotify)imcb_chat_free);
+
+	if (td->tracking_words)
+		g_slist_free_full(td->tracking_words, g_free);
+
 	if (td) {
+		http_close(td->filter_stream);
 		http_close(td->stream);
 		oauth_info_free(td->oauth_info);
 		g_free(td->user);
@@ -501,12 +510,60 @@ static void twitter_chat_invite(struct groupchat *c, char *who, char *message)
 {
 }
 
+static gboolean twitter_subscribe(struct im_connection *ic, const char *keyword)
+{
+	struct twitter_data *td = ic->proto_data;
+	// Filter out 'non-hashtags' and duplicates
+	if (*keyword != '#') {
+		imcb_log(ic, "Error: Can not subscribe to keyword '%s', only hashtags are supported", keyword);
+		return FALSE;
+	}
+
+	if (g_slist_find_custom(td->tracking_words, keyword, (GCompareFunc)g_strcasecmp))
+		return TRUE;
+
+	td->tracking_words = g_slist_append(td->tracking_words, g_strdup(keyword));
+	if (td->stream) 					// do not try to open tracking stream before login is finished
+		twitter_tracking_stream(ic);
+
+	return TRUE;
+}
+
+static void twitter_unsubscribe(struct im_connection *ic, const char *keyword)
+{
+	struct twitter_data *td = ic->proto_data;
+	GSList* el = g_slist_find_custom(td->tracking_words, keyword, (GCompareFunc)g_strcasecmp);
+	td->tracking_words = g_slist_remove(td->tracking_words, el->data);
+	twitter_tracking_stream(ic);
+}
+
+static struct groupchat *twitter_chat_join( struct im_connection *ic, const char *room, const char *nick, const char *password, set_t **sets )
+{
+	struct twitter_data *td = ic->proto_data;
+	struct groupchat *c;
+
+	if (!twitter_subscribe(ic, room))
+		return NULL;
+
+	c = imcb_chat_new(ic, room);
+	imcb_chat_topic(c, NULL, (char *)room, 0); 
+	imcb_chat_add_buddy(c, ic->acc->user);
+
+	td->hashtag_chats = g_slist_append(td->hashtag_chats, c);
+
+	return c;
+}
+
 static void twitter_chat_leave(struct groupchat *c)
 {
 	struct twitter_data *td = c->ic->proto_data;
 
-	if (c != td->timeline_gc)
-		return;		/* WTF? */
+	if (c != td->timeline_gc) {
+		twitter_unsubscribe(c->ic, c->title);
+		td->hashtag_chats = g_slist_remove(td->hashtag_chats, c);
+		imcb_chat_free(c);
+		return;
+	}
 
 	/* If the user leaves the channel: Fine. Rejoin him/her once new
 	   tweets come in. */
@@ -740,6 +797,7 @@ void twitter_initmodule()
 	ret->remove_buddy = twitter_remove_buddy;
 	ret->chat_msg = twitter_chat_msg;
 	ret->chat_invite = twitter_chat_invite;
+	ret->chat_join = twitter_chat_join;
 	ret->chat_leave = twitter_chat_leave;
 	ret->keepalive = twitter_keepalive;
 	ret->add_permit = twitter_add_permit;

--- a/protocols/twitter/twitter.h
+++ b/protocols/twitter/twitter.h
@@ -57,10 +57,13 @@ struct twitter_data
 	guint64 timeline_id;
 
 	GSList *follow_ids;
+	GSList *tracking_words;
+	GSList *hashtag_chats;
 	
 	guint64 last_status_id; /* For undo */
 	gint main_loop_id;
 	struct http_request *stream;
+	struct http_request *filter_stream;
 	struct groupchat *timeline_gc;
 	gint http_fails;
 	twitter_flags_t flags;

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -79,9 +79,11 @@
 #define TWITTER_REPORT_SPAM_URL "/users/report_spam.json"
 
 #define TWITTER_USER_STREAM_URL "https://userstream.twitter.com/1.1/user.json"
+#define TWITTER_FILTER_STREAM_URL "https://stream.twitter.com/1.1/statuses/filter.json"
 
 gboolean twitter_open_stream(struct im_connection *ic);
 gboolean twitter_get_timeline(struct im_connection *ic, gint64 next_cursor);
+void twitter_tracking_stream(struct im_connection *ic);
 void twitter_get_friends_ids(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_statuses_friends(struct im_connection *ic, gint64 next_cursor);
 
@@ -92,6 +94,14 @@ void twitter_status_destroy(struct im_connection *ic, guint64 id);
 void twitter_status_retweet(struct im_connection *ic, guint64 id);
 void twitter_report_spam(struct im_connection *ic, char *screen_name);
 void twitter_favourite_tweet(struct im_connection *ic, guint64 id);
+
+#if (!GLIB_CHECK_VERSION(2,28,0))
+void g_slist_free_full(GSList *list, GDestroyNotify free_func);
+#endif
+
+#if (!GLIB_CHECK_VERSION(2,34,0))
+GSList *g_slist_copy_deep(GSList *list, GCopyFunc func, gpointer user_data);
+#endif
 
 #endif //_TWITTER_LIB_H
 


### PR DESCRIPTION
The review in #12 was a failure. I'd blame you ghosts but I was also somewhat in a hurry to get it merged.

It landed in develop, it was about to get submitted to master but didn't. I just reverted it in 8e68ec107bd9651bbea4af58b4eedb3d23922ae4, mostly because it was becoming annoying to do twitter patches around it.

As I said in that commit:

> It never landed in master because it 'leaks' contacts, as in they never get removed from the channel/blist until the account gets removed, which becomes a big issue with high activity hashtags.
> 
> Sending it back to review, will apply again once it's fixed.

So, known issues for now:
- [ ] Contacts leak
- [ ] The limitation to hashtags is silly
- [ ] Whitespess

I don't even know what else, tbh. Quoting a @ghost reviewer:

```
17:41 <ghost> it needs a lot of work
17:41 <ghost> waaaaay too "hacked" together
```
