### PR TITLE
channel: fixed auto-join occurring when disabled

### DIFF
--- a/irc_channel.c
+++ b/irc_channel.c
@@ -431,7 +431,7 @@ void irc_channel_auto_joins( irc_t *irc, account_t *acc )
 			   can only auto-join them if their account is online. */
 			char *acc_s;
 			
-			if( !aj && !( ic->flags & IRC_CHANNEL_JOINED ) )
+			if( !aj || ( ic->flags & IRC_CHANNEL_JOINED ) )
 				/* Only continue if this one's marked as auto_join
 				   or if we're in it already. (Possible if the
 				   client auto-rejoined it before identyfing.) */


### PR DESCRIPTION
With the auto_join channel flag set to false, the channel is still
auto-joined. This can lead to the channel being "doubly" joined if
a client previously sent a channel join request. The result of being
"doubly" joined is really undefined, but most notably memory leaks
can occur.

It also appears, based on the comment under the modified condition,
the previous condition was incorrect.

Another patch should probably implement some sort of check to ensure a
channel is not already joined, assuming the auto_join flag is enabled.
