### PR TITLE
twitter: implemented filter based group chats

### DIFF
--- a/protocols/twitter/twitter.h
+++ b/protocols/twitter/twitter.h
@@ -44,6 +44,12 @@ typedef enum
 	TWITTER_GOT_MENTIONS   = 0x40000,
 } twitter_flags_t;
 
+typedef enum
+{
+	TWITTER_FILTER_TYPE_FOLLOW = 0,
+	TWITTER_FILTER_TYPE_TRACK
+} twitter_filter_type_t;
+
 struct twitter_log_data;
 
 struct twitter_data
@@ -57,10 +63,13 @@ struct twitter_data
 	guint64 timeline_id;
 
 	GSList *follow_ids;
+	GSList *filters;
 	
 	guint64 last_status_id; /* For undo */
 	gint main_loop_id;
+	gint filter_update_id;
 	struct http_request *stream;
+	struct http_request *filter_stream;
 	struct groupchat *timeline_gc;
 	gint http_fails;
 	twitter_flags_t flags;
@@ -76,6 +85,15 @@ struct twitter_data
 	/* set show_ids */
 	struct twitter_log_data *log;
 	int log_id;
+};
+
+#define TWITTER_FILTER_UPDATE_WAIT 3000
+struct twitter_filter
+{
+	twitter_filter_type_t type;
+	char *text;
+	guint64 uid;
+	GSList *groupchats;
 };
 
 struct twitter_user_data

--- a/protocols/twitter/twitter_lib.h
+++ b/protocols/twitter/twitter_lib.h
@@ -78,9 +78,12 @@
 /* Report spam */
 #define TWITTER_REPORT_SPAM_URL "/users/report_spam.json"
 
+/* Stream URLs */
 #define TWITTER_USER_STREAM_URL "https://userstream.twitter.com/1.1/user.json"
+#define TWITTER_FILTER_STREAM_URL "https://stream.twitter.com/1.1/statuses/filter.json"
 
 gboolean twitter_open_stream(struct im_connection *ic);
+gboolean twitter_open_filter_stream(struct im_connection *ic);
 gboolean twitter_get_timeline(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_friends_ids(struct im_connection *ic, gint64 next_cursor);
 void twitter_get_statuses_friends(struct im_connection *ic, gint64 next_cursor);


### PR DESCRIPTION
Filter group chats allow for the ability to read the tweets of select
users without actually following the users, and/or track keywords or
hashtags. A filter group chat can have multiple users, keywords, or
hashtags. These users, keywords, or hashtags can span multiple group
chats. This allows for rather robust filter organization.

The underlying structure for the filters is based on linked list, as
using the glib hash tables requires >= glib-2.16 for sanity. Since the
glib requirement of bitlbee is only 2.14, linked list are used in order
to prevent an overly complex implementation.

The idea for this patch was inspired by Artem Savkov's "Twitter search
channels" patch.

In order to use the filter group chats, a group chat must be added to
the twitter account. The channel room name is either follow:username,
track:keyword, and/or track:#hashtag. Multiple elements can be used by
separating each element by a semicolon.
