### PR TITLE
[review] Use glib's GChecksum for md5/sha1

### DIFF
--- a/lib/md5.c
+++ b/lib/md5.c
@@ -1,273 +1,32 @@
-/*
- * MD5 hashing code copied from Lepton's crack <http://usuarios.lycos.es/reinob/>
- *
- * Adapted to be API-compatible with the previous (GPL-incompatible) code.
- */
-
-/*
- * This code implements the MD5 message-digest algorithm.
- * The algorithm is due to Ron Rivest.  This code was
- * written by Colin Plumb in 1993, no copyright is claimed.
- * This code is in the public domain; do with it what you wish.
- *
- * Equivalent code is available from RSA Data Security, Inc.
- * This code has been tested against that, and is equivalent,
- * except that you don't need to include two pages of legalese
- * with every copy.
- *
- * To compute the message digest of a chunk of bytes, declare an
- * MD5Context structure, pass it to MD5Init, call MD5Update as
- * needed on buffers full of bytes, and then call MD5Final, which
- * will fill a supplied 16-byte array with the digest.
- */
-
-#include <sys/types.h>
-#include <string.h>		/* for memcpy() */
-#include <stdio.h>
 #include "md5.h"
 
-static void md5_transform(uint32_t buf[4], uint32_t const in[16]);
-
-/*
- * Wrapper function for all-in-one MD5
- *
- * Bernardo Reino, aka Lepton.
- * 20021120
- */
-
-/* Turns out MD5 was designed for little-endian machines. If we're running
-   on a big-endian machines, we have to swap some bytes. Since detecting
-   endianness at compile time reliably seems pretty hard, let's do it at
-   run-time. It's not like we're going to checksum megabytes of data... */
-static uint32_t cvt32(uint32_t val)
-{
-	static int little_endian = -1;
-	
-	if (little_endian == -1)
-	{
-		little_endian = 1;
-		little_endian = *((char*) &little_endian);
-	}
-	
-	if (little_endian)
-		return val;
-	else
-		return (val >> 24) |
-		       ((val >> 8) & 0xff00) |
-		       ((val << 8) & 0xff0000) |
-		       (val << 24);
-}
-
+/* Creates a new GChecksum in ctx */
 void md5_init(struct MD5Context *ctx)
 {
-	ctx->buf[0] = 0x67452301;
-	ctx->buf[1] = 0xefcdab89;
-	ctx->buf[2] = 0x98badcfe;
-	ctx->buf[3] = 0x10325476;
-
-	ctx->bits[0] = 0;
-	ctx->bits[1] = 0;
+	ctx->gchecksum = g_checksum_new(G_CHECKSUM_MD5);
 }
 
-/*
- * Update context to reflect the concatenation of another buffer full
- * of bytes.
- */
-void md5_append(struct MD5Context *ctx, const md5_byte_t *buf,
-		unsigned int len)
+/* Wrapper for g_checksum_update */
+void md5_append(struct MD5Context *ctx, const md5_byte_t *buf, unsigned int len)
 {
-	uint32_t t;
-
-	/* Update bitcount */
-
-	t = ctx->bits[0];
-	if ((ctx->bits[0] = t + ((uint32_t) len << 3)) < t)
-		ctx->bits[1]++;	/* Carry from low to high */
-	ctx->bits[1] += len >> 29;
-
-	t = (t >> 3) & 0x3f;	/* Bytes already in shsInfo->data */
-
-	/* Handle any leading odd-sized chunks */
-
-	if (t) {
-		unsigned char *p = (unsigned char *) ctx->in + t;
-
-		t = 64 - t;
-		if (len < t) {
-			memcpy(p, buf, len);
-			return;
-		}
-		memcpy(p, buf, t);
-		md5_transform(ctx->buf, (uint32_t *) ctx->in);
-		buf += t;
-		len -= t;
-	}
-	/* Process data in 64-byte chunks */
-
-	while (len >= 64) {
-		memcpy(ctx->in, buf, 64);
-		md5_transform(ctx->buf, (uint32_t *) ctx->in);
-		buf += 64;
-		len -= 64;
-	}
-
-	/* Handle any remaining bytes of data. */
-
-	memcpy(ctx->in, buf, len);
+	g_checksum_update(ctx->gchecksum, buf, len);
 }
 
-/*
- * Final wrapup - pad to 64-byte boundary with the bit pattern 
- * 1 0* (64-bit count of bits processed, MSB-first)
- */
+/* Wrapper for g_checksum_get_digest
+ * Also takes care of g_checksum_free(), since it can't be reused anyway
+ * (the GChecksum is closed after get_digest) */
 void md5_finish(struct MD5Context *ctx, md5_byte_t digest[16])
 {
-	unsigned count;
-	unsigned char *p;
-
-	/* Compute number of bytes mod 64 */
-	count = (ctx->bits[0] >> 3) & 0x3F;
-
-	/* Set the first char of padding to 0x80.  This is safe since there is
-	   always at least one byte free */
-	p = ctx->in + count;
-	*p++ = 0x80;
-
-	/* Bytes of padding needed to make 64 bytes */
-	count = 64 - 1 - count;
-
-	/* Pad out to 56 mod 64 */
-	if (count < 8) {
-		/* Two lots of padding:  Pad the first block to 64 bytes */
-		memset(p, 0, count);
-		md5_transform(ctx->buf, (uint32_t *) ctx->in);
-
-		/* Now fill the next block with 56 bytes */
-		memset(ctx->in, 0, 56);
-	} else {
-		/* Pad block to 56 bytes */
-		memset(p, 0, count - 8);
-	}
-
-	/* Append length in bits and transform */
-	((uint32_t *) ctx->in)[14] = cvt32(ctx->bits[0]);
-	((uint32_t *) ctx->in)[15] = cvt32(ctx->bits[1]);
-
-	md5_transform(ctx->buf, (uint32_t *) ctx->in);
-	ctx->buf[0] = cvt32(ctx->buf[0]);
-	ctx->buf[1] = cvt32(ctx->buf[1]);
-	ctx->buf[2] = cvt32(ctx->buf[2]);
-	ctx->buf[3] = cvt32(ctx->buf[3]);
-	memcpy(digest, ctx->buf, 16);
-	memset(ctx, 0, sizeof(*ctx));	/* In case it's sensitive */
+	gsize digest_len = 16;
+	g_checksum_get_digest(ctx->gchecksum, digest, &digest_len);
+	g_checksum_free(ctx->gchecksum);
 }
 
-void md5_finish_ascii(struct MD5Context *context, char *ascii)
+/* Variant of md5_finish that copies the GChecksum
+ * before it enters the "closed" state */
+void md5_digest_keep(struct MD5Context *ctx, md5_byte_t digest[16])
 {
-	md5_byte_t bin[16];
-	int i;
-	
-	md5_finish(context, bin);
-	for (i = 0; i < 16; i ++)
-		sprintf(ascii + i * 2, "%02x", bin[i]);
-}
-
-/* The four core functions - F1 is optimized somewhat */
-
-/* #define F1(x, y, z) (x & y | ~x & z) */
-#define F1(x, y, z) (z ^ (x & (y ^ z)))
-#define F2(x, y, z) F1(z, x, y)
-#define F3(x, y, z) (x ^ y ^ z)
-#define F4(x, y, z) (y ^ (x | ~z))
-
-/* This is the central step in the MD5 algorithm. */
-#define MD5STEP(f, w, x, y, z, data, s) \
-	( w += f(x, y, z) + data,  w = w<<s | w>>(32-s),  w += x )
-
-/*
- * The core of the MD5 algorithm, this alters an existing MD5 hash to
- * reflect the addition of 16 longwords of new data.  MD5Update blocks
- * the data and converts bytes into longwords for this routine.
- */
-static void md5_transform(uint32_t buf[4], uint32_t const in[16])
-{
-	register uint32_t a, b, c, d;
-
-	a = buf[0];
-	b = buf[1];
-	c = buf[2];
-	d = buf[3];
-
-	MD5STEP(F1, a, b, c, d, cvt32(in[0]) + 0xd76aa478, 7);
-	MD5STEP(F1, d, a, b, c, cvt32(in[1]) + 0xe8c7b756, 12);
-	MD5STEP(F1, c, d, a, b, cvt32(in[2]) + 0x242070db, 17);
-	MD5STEP(F1, b, c, d, a, cvt32(in[3]) + 0xc1bdceee, 22);
-	MD5STEP(F1, a, b, c, d, cvt32(in[4]) + 0xf57c0faf, 7);
-	MD5STEP(F1, d, a, b, c, cvt32(in[5]) + 0x4787c62a, 12);
-	MD5STEP(F1, c, d, a, b, cvt32(in[6]) + 0xa8304613, 17);
-	MD5STEP(F1, b, c, d, a, cvt32(in[7]) + 0xfd469501, 22);
-	MD5STEP(F1, a, b, c, d, cvt32(in[8]) + 0x698098d8, 7);
-	MD5STEP(F1, d, a, b, c, cvt32(in[9]) + 0x8b44f7af, 12);
-	MD5STEP(F1, c, d, a, b, cvt32(in[10]) + 0xffff5bb1, 17);
-	MD5STEP(F1, b, c, d, a, cvt32(in[11]) + 0x895cd7be, 22);
-	MD5STEP(F1, a, b, c, d, cvt32(in[12]) + 0x6b901122, 7);
-	MD5STEP(F1, d, a, b, c, cvt32(in[13]) + 0xfd987193, 12);
-	MD5STEP(F1, c, d, a, b, cvt32(in[14]) + 0xa679438e, 17);
-	MD5STEP(F1, b, c, d, a, cvt32(in[15]) + 0x49b40821, 22);
-
-	MD5STEP(F2, a, b, c, d, cvt32(in[1]) + 0xf61e2562, 5);
-	MD5STEP(F2, d, a, b, c, cvt32(in[6]) + 0xc040b340, 9);
-	MD5STEP(F2, c, d, a, b, cvt32(in[11]) + 0x265e5a51, 14);
-	MD5STEP(F2, b, c, d, a, cvt32(in[0]) + 0xe9b6c7aa, 20);
-	MD5STEP(F2, a, b, c, d, cvt32(in[5]) + 0xd62f105d, 5);
-	MD5STEP(F2, d, a, b, c, cvt32(in[10]) + 0x02441453, 9);
-	MD5STEP(F2, c, d, a, b, cvt32(in[15]) + 0xd8a1e681, 14);
-	MD5STEP(F2, b, c, d, a, cvt32(in[4]) + 0xe7d3fbc8, 20);
-	MD5STEP(F2, a, b, c, d, cvt32(in[9]) + 0x21e1cde6, 5);
-	MD5STEP(F2, d, a, b, c, cvt32(in[14]) + 0xc33707d6, 9);
-	MD5STEP(F2, c, d, a, b, cvt32(in[3]) + 0xf4d50d87, 14);
-	MD5STEP(F2, b, c, d, a, cvt32(in[8]) + 0x455a14ed, 20);
-	MD5STEP(F2, a, b, c, d, cvt32(in[13]) + 0xa9e3e905, 5);
-	MD5STEP(F2, d, a, b, c, cvt32(in[2]) + 0xfcefa3f8, 9);
-	MD5STEP(F2, c, d, a, b, cvt32(in[7]) + 0x676f02d9, 14);
-	MD5STEP(F2, b, c, d, a, cvt32(in[12]) + 0x8d2a4c8a, 20);
-
-	MD5STEP(F3, a, b, c, d, cvt32(in[5]) + 0xfffa3942, 4);
-	MD5STEP(F3, d, a, b, c, cvt32(in[8]) + 0x8771f681, 11);
-	MD5STEP(F3, c, d, a, b, cvt32(in[11]) + 0x6d9d6122, 16);
-	MD5STEP(F3, b, c, d, a, cvt32(in[14]) + 0xfde5380c, 23);
-	MD5STEP(F3, a, b, c, d, cvt32(in[1]) + 0xa4beea44, 4);
-	MD5STEP(F3, d, a, b, c, cvt32(in[4]) + 0x4bdecfa9, 11);
-	MD5STEP(F3, c, d, a, b, cvt32(in[7]) + 0xf6bb4b60, 16);
-	MD5STEP(F3, b, c, d, a, cvt32(in[10]) + 0xbebfbc70, 23);
-	MD5STEP(F3, a, b, c, d, cvt32(in[13]) + 0x289b7ec6, 4);
-	MD5STEP(F3, d, a, b, c, cvt32(in[0]) + 0xeaa127fa, 11);
-	MD5STEP(F3, c, d, a, b, cvt32(in[3]) + 0xd4ef3085, 16);
-	MD5STEP(F3, b, c, d, a, cvt32(in[6]) + 0x04881d05, 23);
-	MD5STEP(F3, a, b, c, d, cvt32(in[9]) + 0xd9d4d039, 4);
-	MD5STEP(F3, d, a, b, c, cvt32(in[12]) + 0xe6db99e5, 11);
-	MD5STEP(F3, c, d, a, b, cvt32(in[15]) + 0x1fa27cf8, 16);
-	MD5STEP(F3, b, c, d, a, cvt32(in[2]) + 0xc4ac5665, 23);
-
-	MD5STEP(F4, a, b, c, d, cvt32(in[0]) + 0xf4292244, 6);
-	MD5STEP(F4, d, a, b, c, cvt32(in[7]) + 0x432aff97, 10);
-	MD5STEP(F4, c, d, a, b, cvt32(in[14]) + 0xab9423a7, 15);
-	MD5STEP(F4, b, c, d, a, cvt32(in[5]) + 0xfc93a039, 21);
-	MD5STEP(F4, a, b, c, d, cvt32(in[12]) + 0x655b59c3, 6);
-	MD5STEP(F4, d, a, b, c, cvt32(in[3]) + 0x8f0ccc92, 10);
-	MD5STEP(F4, c, d, a, b, cvt32(in[10]) + 0xffeff47d, 15);
-	MD5STEP(F4, b, c, d, a, cvt32(in[1]) + 0x85845dd1, 21);
-	MD5STEP(F4, a, b, c, d, cvt32(in[8]) + 0x6fa87e4f, 6);
-	MD5STEP(F4, d, a, b, c, cvt32(in[15]) + 0xfe2ce6e0, 10);
-	MD5STEP(F4, c, d, a, b, cvt32(in[6]) + 0xa3014314, 15);
-	MD5STEP(F4, b, c, d, a, cvt32(in[13]) + 0x4e0811a1, 21);
-	MD5STEP(F4, a, b, c, d, cvt32(in[4]) + 0xf7537e82, 6);
-	MD5STEP(F4, d, a, b, c, cvt32(in[11]) + 0xbd3af235, 10);
-	MD5STEP(F4, c, d, a, b, cvt32(in[2]) + 0x2ad7d2bb, 15);
-	MD5STEP(F4, b, c, d, a, cvt32(in[9]) + 0xeb86d391, 21);
-
-	buf[0] += a;
-	buf[1] += b;
-	buf[2] += c;
-	buf[3] += d;
+	GChecksum *copy = g_checksum_copy(ctx->gchecksum);
+	md5_finish(ctx, digest);
+	ctx->gchecksum = copy;
 }

--- a/lib/md5.h
+++ b/lib/md5.h
@@ -1,47 +1,17 @@
-/*
- * MD5 hashing code copied from Lepton's crack <http://usuarios.lycos.es/reinob/>
- *
- * Adapted to be API-compatible with the previous (GPL-incompatible) code.
- */
-
-/*
- * This code implements the MD5 message-digest algorithm.
- * The algorithm is due to Ron Rivest.  This code was
- * written by Colin Plumb in 1993, no copyright is claimed.
- * This code is in the public domain; do with it what you wish.
- *
- * Equivalent code is available from RSA Data Security, Inc.
- * This code has been tested against that, and is equivalent,
- * except that you don't need to include two pages of legalese
- * with every copy.
- *
- * To compute the message digest of a chunk of bytes, declare an
- * MD5Context structure, pass it to MD5Init, call MD5Update as
- * needed on buffers full of bytes, and then call MD5Final, which
- * will fill a supplied 16-byte array with the digest.
- */
-
 #ifndef _MD5_H
 #define _MD5_H
 
-#include <sys/types.h>
+#include <glib.h>
 #include <gmodule.h>
-#if(__sun)
-#include <inttypes.h>
-#else
-#include <stdint.h>
-#endif
 
-typedef uint8_t md5_byte_t;
+typedef guchar md5_byte_t;
 typedef struct MD5Context {
-	uint32_t buf[4];
-	uint32_t bits[2];
-	unsigned char in[64];
+	GChecksum *gchecksum;
 } md5_state_t;
 
 G_MODULE_EXPORT void md5_init(struct MD5Context *context);
 G_MODULE_EXPORT void md5_append(struct MD5Context *context, const md5_byte_t *buf, unsigned int len);
 G_MODULE_EXPORT void md5_finish(struct MD5Context *context, md5_byte_t digest[16]);
-G_MODULE_EXPORT void md5_finish_ascii(struct MD5Context *context, char *ascii);
+G_MODULE_EXPORT void md5_digest_keep(struct MD5Context *context, md5_byte_t digest[16]);
 
 #endif

--- a/lib/sha1.c
+++ b/lib/sha1.c
@@ -1,389 +1,33 @@
-/*
- * SHA1 hashing code copied from Lepton's crack <http://usuarios.lycos.es/reinob/>
- *
- * Adapted to be API-compatible with the previous (GPL-incompatible) code.
- */
-
-/*
- *  sha1.c
- *
- *  Description:
- *      This file implements the Secure Hashing Algorithm 1 as
- *      defined in FIPS PUB 180-1 published April 17, 1995.
- *
- *      The SHA-1, produces a 160-bit message digest for a given
- *      data stream.  It should take about 2**n steps to find a
- *      message with the same digest as a given message and
- *      2**(n/2) to find any two messages with the same digest,
- *      when n is the digest size in bits.  Therefore, this
- *      algorithm can serve as a means of providing a
- *      "fingerprint" for a message.
- *
- *  Portability Issues:
- *      SHA-1 is defined in terms of 32-bit "words".  This code
- *      uses <stdint.h> (included via "sha1.h" to define 32 and 8
- *      bit unsigned integer types.  If your C compiler does not
- *      support 32 bit unsigned integers, this code is not
- *      appropriate.
- *
- *  Caveats:
- *      SHA-1 is designed to work with messages less than 2^64 bits
- *      long.  Although SHA-1 allows a message digest to be generated
- *      for messages of any number of bits less than 2^64, this
- *      implementation only works with messages with a length that is
- *      a multiple of the size of an 8-bit character.
- *
- */
-
+#include "sha1.h"
 #include <string.h>
 #include <stdio.h>
-#include "sha1.h"
 
-/*
- *  Define the SHA1 circular left shift macro
- */
-#define SHA1CircularShift(bits,word) \
-       (((word) << (bits)) | ((word) >> (32-(bits))))
 
-/* Local Function Prototyptes */
-static void sha1_pad(sha1_state_t *);
-static void sha1_process_block(sha1_state_t *);
-
-/*
- *  sha1_init
- *
- *  Description:
- *      This function will initialize the sha1_state_t in preparation
- *      for computing a new SHA1 message digest.
- *
- *  Parameters:
- *      context: [in/out]
- *          The context to reset.
- *
- *  Returns:
- *      sha Error Code.
- *
- */
-int sha1_init(sha1_state_t * context)
+void sha1_init(sha1_state_t *ctx)
 {
-	context->Length_Low = 0;
-	context->Length_High = 0;
-	context->Message_Block_Index = 0;
-
-	context->Intermediate_Hash[0] = 0x67452301;
-	context->Intermediate_Hash[1] = 0xEFCDAB89;
-	context->Intermediate_Hash[2] = 0x98BADCFE;
-	context->Intermediate_Hash[3] = 0x10325476;
-	context->Intermediate_Hash[4] = 0xC3D2E1F0;
-
-	context->Computed = 0;
-	context->Corrupted = 0;
-	
-	return shaSuccess;
+	ctx->gchecksum = g_checksum_new(G_CHECKSUM_SHA1);
 }
 
-/*
- *  sha1_finish
- *
- *  Description:
- *      This function will return the 160-bit message digest into the
- *      Message_Digest array  provided by the caller.
- *      NOTE: The first octet of hash is stored in the 0th element,
- *            the last octet of hash in the 19th element.
- *
- *  Parameters:
- *      context: [in/out]
- *          The context to use to calculate the SHA-1 hash.
- *      Message_Digest: [out]
- *          Where the digest is returned.
- *
- *  Returns:
- *      sha Error Code.
- *
- */
-int sha1_finish(sha1_state_t * context, uint8_t Message_Digest[sha1_hash_size])
+void sha1_append(sha1_state_t *ctx, const guint8 * message_array, guint len)
 {
-	int i;
-
-	if (!context || !Message_Digest) {
-		return shaNull;
-	}
-
-	if (context->Corrupted) {
-		return context->Corrupted;
-	}
-
-	if (!context->Computed) {
-		sha1_pad(context);
-		for (i = 0; i < 64; ++i) {
-			/* message may be sensitive, clear it out */
-			context->Message_Block[i] = 0;
-		}
-		context->Length_Low = 0;	/* and clear length */
-		context->Length_High = 0;
-		context->Computed = 1;
-
-	}
-
-	for (i = 0; i < sha1_hash_size; ++i) {
-		Message_Digest[i] = context->Intermediate_Hash[i >> 2]
-		    >> 8 * (3 - (i & 0x03));
-	}
-
-	return shaSuccess;
+	g_checksum_update(ctx->gchecksum, message_array, len);
 }
 
-/*
- *  sha1_append
- *
- *  Description:
- *      This function accepts an array of octets as the next portion
- *      of the message.
- *
- *  Parameters:
- *      context: [in/out]
- *          The SHA context to update
- *      message_array: [in]
- *          An array of characters representing the next portion of
- *          the message.
- *      length: [in]
- *          The length of the message in message_array
- *
- *  Returns:
- *      sha Error Code.
- *
- */
-int
-sha1_append(sha1_state_t * context,
-	  const uint8_t * message_array, unsigned length)
+void sha1_finish(sha1_state_t *ctx, guint8 digest[sha1_hash_size])
 {
-	if (!length) {
-		return shaSuccess;
-	}
-
-	if (!context || !message_array) {
-		return shaNull;
-	}
-
-	if (context->Computed) {
-		context->Corrupted = shaStateError;
-
-		return shaStateError;
-	}
-
-	if (context->Corrupted) {
-		return context->Corrupted;
-	}
-	while (length-- && !context->Corrupted) {
-		context->Message_Block[context->Message_Block_Index++] =
-		    (*message_array & 0xFF);
-
-		context->Length_Low += 8;
-		if (context->Length_Low == 0) {
-			context->Length_High++;
-			if (context->Length_High == 0) {
-				/* Message is too long */
-				context->Corrupted = 1;
-			}
-		}
-
-		if (context->Message_Block_Index == 64) {
-			sha1_process_block(context);
-		}
-
-		message_array++;
-	}
-
-	return shaSuccess;
-}
-
-/*
- *  sha1_process_block
- *
- *  Description:
- *      This function will process the next 512 bits of the message
- *      stored in the Message_Block array.
- *
- *  Parameters:
- *      None.
- *
- *  Returns:
- *      Nothing.
- *
- *  Comments:
- *      Many of the variable names in this code, especially the
- *      single character names, were used because those were the
- *      names used in the publication.
- *
- *
- */
-static void sha1_process_block(sha1_state_t * context)
-{
-	const uint32_t K[] = {	/* Constants defined in SHA-1   */
-		0x5A827999,
-		0x6ED9EBA1,
-		0x8F1BBCDC,
-		0xCA62C1D6
-	};
-	int t;			/* Loop counter                */
-	uint32_t temp;		/* Temporary word value        */
-	uint32_t W[80];		/* Word sequence               */
-	uint32_t A, B, C, D, E;	/* Word buffers                */
-
-	/*
-	 *  Initialize the first 16 words in the array W
-	 */
-	for (t = 0; t < 16; t++) {
-		W[t] = context->Message_Block[t * 4] << 24;
-		W[t] |= context->Message_Block[t * 4 + 1] << 16;
-		W[t] |= context->Message_Block[t * 4 + 2] << 8;
-		W[t] |= context->Message_Block[t * 4 + 3];
-	}
-
-	for (t = 16; t < 80; t++) {
-		W[t] =
-		    SHA1CircularShift(1,
-				      W[t - 3] ^ W[t - 8] ^ W[t -
-							      14] ^ W[t -
-								      16]);
-	}
-
-	A = context->Intermediate_Hash[0];
-	B = context->Intermediate_Hash[1];
-	C = context->Intermediate_Hash[2];
-	D = context->Intermediate_Hash[3];
-	E = context->Intermediate_Hash[4];
-
-	for (t = 0; t < 20; t++) {
-		temp = SHA1CircularShift(5, A) +
-		    ((B & C) | ((~B) & D)) + E + W[t] + K[0];
-		E = D;
-		D = C;
-		C = SHA1CircularShift(30, B);
-
-		B = A;
-		A = temp;
-	}
-
-	for (t = 20; t < 40; t++) {
-		temp =
-		    SHA1CircularShift(5,
-				      A) + (B ^ C ^ D) + E + W[t] + K[1];
-		E = D;
-		D = C;
-		C = SHA1CircularShift(30, B);
-		B = A;
-		A = temp;
-	}
-
-	for (t = 40; t < 60; t++) {
-		temp = SHA1CircularShift(5, A) +
-		    ((B & C) | (B & D) | (C & D)) + E + W[t] + K[2];
-		E = D;
-		D = C;
-		C = SHA1CircularShift(30, B);
-		B = A;
-		A = temp;
-	}
-
-	for (t = 60; t < 80; t++) {
-		temp =
-		    SHA1CircularShift(5,
-				      A) + (B ^ C ^ D) + E + W[t] + K[3];
-		E = D;
-		D = C;
-		C = SHA1CircularShift(30, B);
-		B = A;
-		A = temp;
-	}
-
-	context->Intermediate_Hash[0] += A;
-	context->Intermediate_Hash[1] += B;
-	context->Intermediate_Hash[2] += C;
-	context->Intermediate_Hash[3] += D;
-	context->Intermediate_Hash[4] += E;
-
-	context->Message_Block_Index = 0;
-}
-
-/*
- *  sha1_pad
- *
- *  Description:
- *      According to the standard, the message must be padded to an even
- *      512 bits.  The first padding bit must be a '1'.  The last 64
- *      bits represent the length of the original message.  All bits in
- *      between should be 0.  This function will pad the message
- *      according to those rules by filling the Message_Block array
- *      accordingly.  It will also call the ProcessMessageBlock function
- *      provided appropriately.  When it returns, it can be assumed that
- *      the message digest has been computed.
- *
- *  Parameters:
- *      context: [in/out]
- *          The context to pad
- *      ProcessMessageBlock: [in]
- *          The appropriate SHA*ProcessMessageBlock function
- *  Returns:
- *      Nothing.
- *
- */
-
-static void sha1_pad(sha1_state_t * context)
-{
-	/*
-	 *  Check to see if the current message block is too small to hold
-	 *  the initial padding bits and length.  If so, we will pad the
-	 *  block, process it, and then continue padding into a second
-	 *  block.
-	 */
-	if (context->Message_Block_Index > 55) {
-		context->Message_Block[context->Message_Block_Index++] =
-		    0x80;
-		while (context->Message_Block_Index < 64) {
-			context->Message_Block[context->
-					       Message_Block_Index++] = 0;
-		}
-
-		sha1_process_block(context);
-
-		while (context->Message_Block_Index < 56) {
-			context->Message_Block[context->
-					       Message_Block_Index++] = 0;
-		}
-	} else {
-		context->Message_Block[context->Message_Block_Index++] =
-		    0x80;
-		while (context->Message_Block_Index < 56) {
-
-			context->Message_Block[context->
-					       Message_Block_Index++] = 0;
-		}
-	}
-
-	/*
-	 *  Store the message length as the last 8 octets
-	 */
-	context->Message_Block[56] = context->Length_High >> 24;
-	context->Message_Block[57] = context->Length_High >> 16;
-	context->Message_Block[58] = context->Length_High >> 8;
-	context->Message_Block[59] = context->Length_High;
-	context->Message_Block[60] = context->Length_Low >> 24;
-	context->Message_Block[61] = context->Length_Low >> 16;
-	context->Message_Block[62] = context->Length_Low >> 8;
-	context->Message_Block[63] = context->Length_Low;
-
-	sha1_process_block(context);
+	gsize digest_len = sha1_hash_size;
+	g_checksum_get_digest(ctx->gchecksum, digest, &digest_len);
+	g_checksum_free(ctx->gchecksum);
 }
 
 #define HMAC_BLOCK_SIZE 64
 
 /* BitlBee addition: */
-void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t payload_len, uint8_t Message_Digest[sha1_hash_size])
+void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t payload_len, guint8 digest[sha1_hash_size])
 {
 	sha1_state_t sha1;
-	uint8_t hash[sha1_hash_size];
-	uint8_t key[HMAC_BLOCK_SIZE+1];
+	guint8 hash[sha1_hash_size];
+	guint8 key[HMAC_BLOCK_SIZE+1];
 	int i;
 	
 	if( key_len == 0 )
@@ -397,7 +41,7 @@ void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t pay
 	if( key_len > HMAC_BLOCK_SIZE )
 	{
 		sha1_init( &sha1 );
-		sha1_append( &sha1, (uint8_t*) key_, key_len );
+		sha1_append( &sha1, (guint8*) key_, key_len );
 		sha1_finish( &sha1, key );
 	}
 	else
@@ -410,7 +54,7 @@ void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t pay
 	for( i = 0; i < HMAC_BLOCK_SIZE; i ++ )
 		key[i] ^= 0x36;
 	sha1_append( &sha1, key, HMAC_BLOCK_SIZE );
-	sha1_append( &sha1, (const uint8_t*) payload, payload_len );
+	sha1_append( &sha1, (const guint8*) payload, payload_len );
 	sha1_finish( &sha1, hash );
 	
 	/* Final result: H(K XOR 0x5C, inner stuff) */
@@ -419,7 +63,7 @@ void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t pay
 		key[i] ^= 0x36 ^ 0x5c;
 	sha1_append( &sha1, key, HMAC_BLOCK_SIZE );
 	sha1_append( &sha1, hash, sha1_hash_size );
-	sha1_finish( &sha1, Message_Digest );
+	sha1_finish( &sha1, digest );
 }
 
 /* I think this follows the scheme described on:
@@ -430,7 +74,7 @@ void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t pay
    Returns a value that must be free()d. */
 char *sha1_random_uuid( sha1_state_t * context )
 {
-	uint8_t dig[sha1_hash_size];
+	guint8 dig[sha1_hash_size];
 	char *ret = g_new0( char, 40 ); /* 36 chars + \0 */
 	int i, p;
 	

--- a/lib/sha1.h
+++ b/lib/sha1.h
@@ -1,72 +1,20 @@
-/*
- * SHA1 hashing code copied from Lepton's crack <http://usuarios.lycos.es/reinob/>
- *
- * Adapted to be API-compatible with the previous (GPL-incompatible) code.
- */
-
-/*
- *  sha1.h
- *
- *  Description:
- *      This is the header file for code which implements the Secure
- *      Hashing Algorithm 1 as defined in FIPS PUB 180-1 published
- *      April 17, 1995.
- *
- *      Many of the variable names in this code, especially the
- *      single character names, were used because those were the names
- *      used in the publication.
- *
- *      Please read the file sha1.c for more information.
- *
- */
 
 #ifndef _SHA1_H_
 #define _SHA1_H_
 
-#if(__sun)
-#include <inttypes.h>
-#else
-#include <stdint.h>
-#endif
+#include <glib.h>
 #include <gmodule.h>
 
-#ifndef _SHA_enum_
-#define _SHA_enum_
-enum {
-	shaSuccess = 0,
-	shaNull,		/* Null pointer parameter */
-	shaInputTooLong,	/* input data too long */
-	shaStateError		/* called Input after Result */
-};
-#endif
 #define sha1_hash_size 20
 
-/*
- *  This structure will hold context information for the SHA-1
- *  hashing operation
- */
 typedef struct SHA1Context {
-	uint32_t Intermediate_Hash[sha1_hash_size/4];	/* Message Digest   */
-
-	uint32_t Length_Low;            /* Message length in bits           */
-	uint32_t Length_High;           /* Message length in bits           */
-
-	/* Index into message block array   */
-	int_least16_t Message_Block_Index;
-	uint8_t Message_Block[64];	/* 512-bit message blocks           */
-
-	int Computed;                   /* Is the digest computed?          */
-	int Corrupted;                  /* Is the message digest corrupted? */
+	GChecksum *gchecksum;
 } sha1_state_t;
 
-/*
- *  Function Prototypes
- */
-
-G_MODULE_EXPORT int sha1_init(sha1_state_t *);
-G_MODULE_EXPORT int sha1_append(sha1_state_t *, const uint8_t *, unsigned int);
-G_MODULE_EXPORT int sha1_finish(sha1_state_t *, uint8_t Message_Digest[sha1_hash_size]);
-G_MODULE_EXPORT void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t payload_len, uint8_t Message_Digest[sha1_hash_size]);
+G_MODULE_EXPORT void sha1_init(sha1_state_t *);
+G_MODULE_EXPORT void sha1_append(sha1_state_t *, const guint8 *, unsigned int);
+G_MODULE_EXPORT void sha1_finish(sha1_state_t *, guint8 digest[sha1_hash_size]);
+G_MODULE_EXPORT void sha1_hmac(const char *key_, size_t key_len, const char *payload, size_t payload_len, guint8 digest[sha1_hash_size]);
 G_MODULE_EXPORT char *sha1_random_uuid( sha1_state_t * context );
 
 #endif

--- a/protocols/jabber/jabber_util.c
+++ b/protocols/jabber/jabber_util.c
@@ -147,7 +147,7 @@ void jabber_cache_add( struct im_connection *ic, struct xt_node *node, jabber_ca
 	
 	id_hash = jd->cached_id_prefix;
 	md5_append( &id_hash, (md5_byte_t*) &next_id, sizeof( next_id ) );
-	md5_finish( &id_hash, id_sum );
+	md5_digest_keep( &id_hash, id_sum );
 	asc_hash = base64_encode( id_sum, 12 );
 	
 	id = g_strdup_printf( "%s%s", JABBER_CACHED_ID, asc_hash );


### PR DESCRIPTION
Part of #25, requires glib 2.16

---

This changes behavior slightly:
- md5_init()/sha1_init() allocate a GChecksum
- md5_finish()/sha1_finish() close and free() it
- md5_digest_keep() was added (no sha1 equivalent needed)

And yes, glib has this concept of "closing" the GChecksum, which means
it can't be used anymore after g_checksum_get_digest().

jabber_cache_add() actually seems to need to do that to generate some
random-ish values, so i kept that working by adding a md5_digest_keep()
function that copies the GChecksum before it gets closed
